### PR TITLE
fix: missing command

### DIFF
--- a/docs/processes/github/ssh-setup.md
+++ b/docs/processes/github/ssh-setup.md
@@ -74,6 +74,9 @@ Test your connection:
     
     In order to try this out, using the terminal go to any **git project** inside `~/Code/wonderland` and paste the following:
     
+    ```bash
+    git config --get user.name && git config --get user.email
+    ```
     That command should print your anon git information.
 
 ### 4. Configure your SSH


### PR DESCRIPTION
Closes issue [18](https://github.com/defi-wonderland/handbook/issues/18) and [CHA-230](https://linear.app/defi-wonderland/issue/CHA-230/bug-in-ssh-set-up)