### PR TITLE
feat: enable navigation in-app

### DIFF
--- a/packages/common-config/preset/commonDocusaurusConfig.ts
+++ b/packages/common-config/preset/commonDocusaurusConfig.ts
@@ -43,12 +43,12 @@ const commonDocusaurusConfig: Partial<Config> = {
           items: [
             {
               label: "Wonderland",
-              to: "https://handbook.wonderland.xyz",
+              to: "https://handbook-git-feat-vercel-rewrites-defi-wonderland.vercel.app/",
               target: "_self",
             },
             {
               label: "Optimism",
-              to: "https://handbook.wonderland.xyz/optimism",
+              to: "https://handbook-git-feat-vercel-rewrites-defi-wonderland.vercel.app/optimism",
               target: "_self",
             },
             // // TODO: Enable when Aztec handbook is ready

--- a/packages/common-config/preset/commonDocusaurusConfig.ts
+++ b/packages/common-config/preset/commonDocusaurusConfig.ts
@@ -43,12 +43,12 @@ const commonDocusaurusConfig: Partial<Config> = {
           items: [
             {
               label: "Wonderland",
-              to: "https://handbook-git-feat-vercel-rewrites-defi-wonderland.vercel.app/",
+              to: "https://handbook.wonderland.xyz",
               target: "_self",
             },
             {
               label: "Optimism",
-              to: "https://handbook-git-feat-vercel-rewrites-defi-wonderland.vercel.app/optimism",
+              to: "https://optimism.handbook.wonderland.xyz",
               target: "_self",
             },
             // // TODO: Enable when Aztec handbook is ready

--- a/packages/common-config/preset/commonDocusaurusConfig.ts
+++ b/packages/common-config/preset/commonDocusaurusConfig.ts
@@ -43,13 +43,11 @@ const commonDocusaurusConfig: Partial<Config> = {
           items: [
             {
               label: "Wonderland",
-              to: "/",
+              to: "https://handbook.wonderland.xyz",
             },
             {
               label: "Optimism",
               to: "https://handbook.wonderland.xyz/optimism",
-              target: "_blank",
-              rel: "noopener noreferrer",
             },
             // // TODO: Enable when Aztec handbook is ready
             // // TODO: Remember to add the rewrite in vercel.json!

--- a/packages/common-config/preset/commonDocusaurusConfig.ts
+++ b/packages/common-config/preset/commonDocusaurusConfig.ts
@@ -44,10 +44,12 @@ const commonDocusaurusConfig: Partial<Config> = {
             {
               label: "Wonderland",
               to: "https://handbook.wonderland.xyz",
+              target: "_self",
             },
             {
               label: "Optimism",
               to: "https://handbook.wonderland.xyz/optimism",
+              target: "_self",
             },
             // // TODO: Enable when Aztec handbook is ready
             // // TODO: Remember to add the rewrite in vercel.json!

--- a/sites/optimism/README.md
+++ b/sites/optimism/README.md
@@ -4,32 +4,35 @@ This repository contains the Onboarding to Optimism by Wonderland, a documentati
 
 ## Structure
 
-- `handbook/` - Contains the Docusaurus website source code
-  - `docs/` - Documentation content in Markdown format
-  - `src/` - Custom React components and styles
-  - `docusaurus.config.js` - Main Docusaurus configuration
-  - `sidebar.ts` - Indexer for the docs
+- `docs/` - Documentation content in Markdown format
+- `src/` - Custom React components and styles
+- `static/` - Static assets (images, fonts, etc.)
+  - `common/` - Shared assets from the monorepo (gitignored)
+- `docusaurus.config.ts` - Main Docusaurus configuration
+- `sidebars.ts` - Indexer for the docs
 
 ## Development
 
 ### Prerequisites
 
-- Node.js (v16 or higher)
-- Yarn package manager
+- Node.js (v18 or higher)
+- pnpm package manager
 
 ### Local Development
+
+From the root of the monorepo:
 
 1. Install dependencies:
 
 ```bash
-cd op-handbook
-npm i
+pnpm install
 ```
 
-2. Start the development server:
+2. Build common assets and start the development server:
 
 ```bash
-npm run start
+pnpm --filter optimism-handbook build:assets
+pnpm --filter optimism-handbook start
 ```
 
 This will start a local development server and open your browser. Changes are reflected in real-time.
@@ -39,11 +42,10 @@ This will start a local development server and open your browser. Changes are re
 To create a production build:
 
 ```bash
-cd op-handbook
-npm run build
+pnpm --filter optimism-handbook build
 ```
 
-The static site will be generated in the `op-handbook/build` directory.
+The static site will be generated in the `sites/optimism/build` directory.
 
 ### Deployment
 
@@ -52,8 +54,13 @@ The handbook is automatically deployed to Vercel when changes are pushed to the 
 ## Contributing
 
 1. Create a new branch for your changes
-2. Make your changes in the `op-handbook/docs` directory
-3. Test locally using `npm run start`
-4. Submit a pull request
+2. Make your changes in the `sites/optimism/docs` directory
+3. If you add new folders or files, you must also update `sidebars.ts`:
+
+- This file defines the sidebar navigation using [Docusaurus sidebar configuration](https://docusaurus.io/docs/sidebar).
+- Add your new documents to the appropriate category, or create a new one as needed.
+
+4. Test locally using `pnpm --filter optimism-handbook start`
+5. Submit a pull request
 
 If you have any ideas for improving the handbook, feel free to open an issue (check the templates!) to start a discussion!

--- a/sites/optimism/docusaurus.config.ts
+++ b/sites/optimism/docusaurus.config.ts
@@ -11,7 +11,7 @@ const localConfig: Config = {
   favicon: "img/favicon.ico",
 
   // Set the production url of your site here
-  url: "https://optimism.handbook.defi.sucks",
+  url: "https://optimism.handbook.wonderland.xyz",
   // Set the /<baseUrl>/ pathname under which your site is served
   // For GitHub pages deployment, it is often '/<projectName>/'
   baseUrl: "/",

--- a/sites/optimism/docusaurus.config.ts
+++ b/sites/optimism/docusaurus.config.ts
@@ -11,7 +11,7 @@ const localConfig: Config = {
   favicon: "img/favicon.ico",
 
   // Set the production url of your site here
-  url: "https://optimism.handbook.wonderland.xyz",
+  url: "https://op-handbook-git-feat-vercel-rewrites-defi-wonderland.vercel.app",
   // Set the /<baseUrl>/ pathname under which your site is served
   // For GitHub pages deployment, it is often '/<projectName>/'
   baseUrl: "/",

--- a/sites/optimism/docusaurus.config.ts
+++ b/sites/optimism/docusaurus.config.ts
@@ -14,7 +14,7 @@ const localConfig: Config = {
   url: "https://op-handbook-git-feat-vercel-rewrites-defi-wonderland.vercel.app",
   // Set the /<baseUrl>/ pathname under which your site is served
   // For GitHub pages deployment, it is often '/<projectName>/'
-  baseUrl: "/",
+  baseUrl: "/optimism/",
   organizationName: "defi-wonderland",
   projectName: "op-handbook",
 

--- a/sites/optimism/docusaurus.config.ts
+++ b/sites/optimism/docusaurus.config.ts
@@ -11,10 +11,10 @@ const localConfig: Config = {
   favicon: "img/favicon.ico",
 
   // Set the production url of your site here
-  url: "https://op-handbook-git-feat-vercel-rewrites-defi-wonderland.vercel.app",
+  url: "https://optimism.handbook.wonderland.xyz",
   // Set the /<baseUrl>/ pathname under which your site is served
   // For GitHub pages deployment, it is often '/<projectName>/'
-  baseUrl: "/optimism/",
+  baseUrl: "/",
   organizationName: "defi-wonderland",
   projectName: "op-handbook",
 

--- a/sites/optimism/src/pages/index.tsx
+++ b/sites/optimism/src/pages/index.tsx
@@ -38,7 +38,7 @@ const optimismHeroProps: HeroSectionProps = {
   title: "OP Handbook",
   titleImage: "/img/op-handbook-social.svg",
   description:
-    "At Wonderland, we believe that the ecosystem thrives on collaboration and shared knowledge. This handbook is our living repository: a curated guide to our best practices, processes, and technical insights.",
+    "New to Optimism? This handbook is your guide through all the things you need to know before you get started. Cheers!",
   buttonText: "Enter the Rabbit Hole",
   buttonImage: "/common/img/enter-button.svg",
   buttonLink: "/docs/welcome",

--- a/sites/optimism/src/pages/index.tsx
+++ b/sites/optimism/src/pages/index.tsx
@@ -48,7 +48,7 @@ const optimismHandbooks: Handbook[] = [
   {
     title: "Wonderland Handbook",
     image: "/common/img/wonderland-button-image.png",
-    href: "https://handbook.wonderland.xyz",
+    href: "https://handbook-git-feat-vercel-rewrites-defi-wonderland.vercel.app",
     background: {
       bgType: "other",
       bgImage: "/common/img/wonderland-button-bg.jpg",

--- a/sites/optimism/src/pages/index.tsx
+++ b/sites/optimism/src/pages/index.tsx
@@ -48,7 +48,7 @@ const optimismHandbooks: Handbook[] = [
   {
     title: "Wonderland Handbook",
     image: "/common/img/wonderland-button-image.png",
-    href: "https://handbook-git-feat-vercel-rewrites-defi-wonderland.vercel.app",
+    href: "https://handbook.wonderland.xyz",
     background: {
       bgType: "other",
       bgImage: "/common/img/wonderland-button-bg.jpg",

--- a/sites/template/docusaurus.config.ts
+++ b/sites/template/docusaurus.config.ts
@@ -15,9 +15,8 @@ const localConfig: Config = {
 
   // Set the production url of your site here
   url: "https://your-domain.com/",
-  // Set the /<baseUrl>/ pathname under which your site is served
-  // For GitHub pages deployment, it is often '/<projectName>/'
-  baseUrl: "/",
+  // IMPORTANT: Change this to your project name, and add the vercel rewrite in /wonderland/vercel.json
+  baseUrl: "/your-project/",
 
   // GitHub pages deployment config.
   // If you aren't using GitHub pages, you don't need these.

--- a/sites/template/docusaurus.config.ts
+++ b/sites/template/docusaurus.config.ts
@@ -15,8 +15,9 @@ const localConfig: Config = {
 
   // Set the production url of your site here
   url: "https://your-domain.com/",
-  // IMPORTANT: Change this to your project name, and add the vercel rewrite in /wonderland/vercel.json
-  baseUrl: "/your-project/",
+  // Set the /<baseUrl>/ pathname under which your site is served
+  // For GitHub pages deployment, it is often '/<projectName>/'
+  baseUrl: "/",
 
   // GitHub pages deployment config.
   // If you aren't using GitHub pages, you don't need these.
@@ -31,7 +32,7 @@ const localConfig: Config = {
           sidebarPath: "./sidebars.ts",
           // Please change this to your repo.
           // Remove this to remove the 'edit this page' links.
-          editUrl: "https://github.com/your-organization/your-project/tree/main/",
+          editUrl: "https://github.com/defi-wonderland/handbook/tree/main/",
           remarkPlugins: [remarkMath],
           rehypePlugins: [rehypeKatex],
         },

--- a/sites/wonderland/docusaurus.config.ts
+++ b/sites/wonderland/docusaurus.config.ts
@@ -14,7 +14,7 @@ const localConfig: Config = {
   favicon: "img/favicon.ico",
 
   // Set the production url of your site here
-  url: "https://handbook.defi.sucks/",
+  url: "https://handbook.wonderland.xyz",
   // Set the /<baseUrl>/ pathname under which your site is served
   // For GitHub pages deployment, it is often '/<projectName>/'
   baseUrl: "/",

--- a/sites/wonderland/src/pages/index.tsx
+++ b/sites/wonderland/src/pages/index.tsx
@@ -53,7 +53,7 @@ const wonderlandHandbooks: Handbook[] = [
   {
     title: "Optimism handbook",
     image: "/img/optimism-handbook.svg",
-    href: "/optimism",
+    href: "https://optimism.handbook.wonderland.xyz",
     background: {
       bgType: "other",
       bgImage: "/common/img/background-handbook-card.jpg",

--- a/sites/wonderland/vercel.json
+++ b/sites/wonderland/vercel.json
@@ -1,8 +1,0 @@
-{
-  "rewrites": [
-    {
-      "source": "/optimism(/.*)?",
-      "destination": "https://op-handbook-git-feat-vercel-rewrites-defi-wonderland.vercel.app$1"
-    }
-  ]
-}

--- a/sites/wonderland/vercel.json
+++ b/sites/wonderland/vercel.json
@@ -2,7 +2,7 @@
   "rewrites": [
     {
       "source": "/optimism(/.*)?",
-      "destination": "https://optimism.handbook.wonderland.xyz$1"
+      "destination": "https://op-handbook-git-feat-vercel-rewrites-defi-wonderland.vercel.app$1"
     }
   ]
 }

--- a/sites/wonderland/vercel.json
+++ b/sites/wonderland/vercel.json
@@ -2,7 +2,7 @@
   "rewrites": [
     {
       "source": "/optimism(/.*)?",
-      "destination": "https://optimism.handbook.defi.sucks$1"
+      "destination": "https://optimism.handbook.wonderland.xyz$1"
     }
   ]
 }


### PR DESCRIPTION
Enable navigation between handbooks. For instance, going to https://handbook.wonderland.xyz/optimism will render optimism.handbook.wonderland.xyz behind the scenes

closes https://linear.app/defi-wonderland/issue/CHA-346/enable-handbook-navigation

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Updated the Optimism Handbook README to reflect new directory structure, tooling (pnpm, Node.js v18+), and contribution guidelines.
  * Revised the homepage description to better welcome newcomers to Optimism.
* **Chores**
  * Updated production URLs and rewrite rules to use the new Vercel deployment domain.
  * Adjusted navigation links and attributes in the site navbar for improved accuracy.
  * Modified base URL settings and related configuration comments for project-specific deployment paths.
  * Updated edit URL in template site configuration to point to the correct repository.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->