### PR TITLE
fix: update links

### DIFF
--- a/sites/optimism/docs/processes/projects.md
+++ b/sites/optimism/docs/processes/projects.md
@@ -9,3 +9,5 @@ sidebar_label: Projects
 ## Project Tracking
 
 We maintain multiple projects in parallel, each with its own scope, timeline, and deliverables. To stay updated on project status and review past work, visit our [Optimism Projects](https://www.notion.so/Optimism-Projects-1aa9a4c092c780f3a7dffa355fa620d9?pvs=21) Notion page.
+
+> ⚠️ **Note:** The following link is private, you will be able to access if you are in the wonderland org.

--- a/sites/wonderland/docs/development/offchain/best-practices.md
+++ b/sites/wonderland/docs/development/offchain/best-practices.md
@@ -1,4 +1,3 @@
-
 # Best Practices
 
 This document outlines the key principles, patterns, and practices for the Offchain department. It serves as a guide to ensure consistency, scalability, and maintainability in our projects, covering design patterns, architectural principles, TypeScript best practices, testing, scripting, and documentation standards.
@@ -8,9 +7,9 @@ By adhering to these guidelines, we ensure robust and modular development, foste
 ## Patterns
 
 - Design Patterns:
-    - **Factory**: Creates objects dynamically based on input or configuration without exposing the instantiation logic.
-    - **Proxy**: Acts as a placeholder to control access, add caching, or optimize performance.
-    - **Singleton**: Ensures a class has only one instance and provides a global point of access to it.
+  - **Factory**: Creates objects dynamically based on input or configuration without exposing the instantiation logic.
+  - **Proxy**: Acts as a placeholder to control access, add caching, or optimize performance.
+  - **Singleton**: Ensures a class has only one instance and provides a global point of access to it.
 
 ## **Principles**
 
@@ -18,11 +17,11 @@ By adhering to these guidelines, we ensure robust and modular development, foste
 - Favor **composition over inheritance** to build reusable and flexible components.
 - Use **dependency injection** to decouple components and facilitate testing.
 - Follow **SOLID principles**:
-    1. **Single Responsibility Principle**: A class should have one and only one reason to change.
-    2. **Open/Closed Principle**: Software entities should be open for extension but closed for modification.
-    3. **Liskov Substitution Principle**: Derived classes must be substitutable for their base classes.
-    4. **Interface Segregation Principle**: Many specific interfaces are better than a single, general-purpose interface.
-    5. **Dependency Inversion Principle**: Depend on abstractions, not concretions.
+  1. **Single Responsibility Principle**: A class should have one and only one reason to change.
+  2. **Open/Closed Principle**: Software entities should be open for extension but closed for modification.
+  3. **Liskov Substitution Principle**: Derived classes must be substitutable for their base classes.
+  4. **Interface Segregation Principle**: Many specific interfaces are better than a single, general-purpose interface.
+  5. **Dependency Inversion Principle**: Depend on abstractions, not concretions.
 
 ### **Architectural Patterns**
 
@@ -35,8 +34,8 @@ By adhering to these guidelines, we ensure robust and modular development, foste
 ### **1. Module Structure**
 
 - Follow the [Internal Module Pattern](https://medium.com/visual-development/how-to-fix-nasty-circular-dependency-issues-once-and-for-all-in-javascript-typescript-a04c987cf0de) to avoid circular dependencies:
-    - Create an `external.ts` file to explicitly list exported components, types, and interfaces.
-    - Import and re-export them in the entry `index.ts` file for easier access.
+  - Create an `external.ts` file to explicitly list exported components, types, and interfaces.
+  - Import and re-export them in the entry `index.ts` file for easier access.
 
 ### **2. Asynchronous Initialization**
 
@@ -45,15 +44,15 @@ By adhering to these guidelines, we ensure robust and modular development, foste
 ### **3. Runtime Type Checking**
 
 - Validate environment variables at runtime using libraries like:
-    - [Zod](https://zod.dev/)
-    - [t3-env](https://github.com/t3-oss/t3-env)
-    - [envalid](https://github.com/af/envalid).
+  - [Zod](https://zod.dev/)
+  - [t3-env](https://github.com/t3-oss/t3-env)
+  - [envalid](https://github.com/af/envalid).
 
 ### **4. Type Safety**
 
 - Avoid the use of `any`; prefer `unknown` and use type narrowing to ensure safety.
 - Leverage Branded types pattern for adding clarity, safety and correctness to our code:
-    https://egghead.io/blog/using-branded-types-in-typescript
+  https://egghead.io/blog/using-branded-types-in-typescript
 
 ## Naming conventions
 
@@ -62,9 +61,9 @@ By adhering to these guidelines, we ensure robust and modular development, foste
 A `Service` typically encapsulates a broader business logic or workflow. It might orchestrate various components or interact with multiple data sources or APIs to fulfill a specific domain-related task.
 A `Provider` usually focuses on supplying a specific type of data or resource. It’s often more narrowly scoped, providing access to a particular piece of data, a configuration, or a service needed by other parts of the application.
 
-Ex: 
+Ex:
 
-- Classes that interacts with a metadata source like `Github` ,`JsonFile` &`Ipfs`  should implement the interface `IMetadataProvider` and should be called `GithubProvider,JsonFileProvider` &`IpfsProvider`.
+- Classes that interacts with a metadata source like `Github` ,`JsonFile` &`Ipfs` should implement the interface `IMetadataProvider` and should be called `GithubProvider,JsonFileProvider` &`IpfsProvider`.
 - A class that aggregates multiple sources like `Metadata` ,`Pricing` &`BlockchainEvents` , should be called, for example, `AgreggatorService` the word aggregator might change, based on the bussiness logic. Could be, for example, `MetricsService` .
 
 If we look at it from composability a `Service` can be made up of `Providers` and the service works on applying the business and orchestration logic
@@ -73,28 +72,28 @@ If we look at it from composability a `Service` can be made up of `Providers` an
 
 - Enable the `useUnknownInCatchVariables` flag in your `tsconfig.json`
 - Enable the `noUncheckedIndexedAccess` flag for safe object access
-- Avoid throwing literals like, enforce it with an ESLint rule (https://typescript-eslint.io/rules/no-throw-literal/
+- Avoid throwing literals like, enforce it with an ESLint rule https://eslint.org/docs/latest/rules/no-throw-literal
 - Write custom error classes
-    - Use declarative and descriptive names
-    - Avoid the usage of suffixes like `Exception` or `Error` :
-        - Ex: Don’t write `EmptyArrayException`, write `EmptyArray`
+  - Use declarative and descriptive names
+  - Avoid the usage of suffixes like `Exception` or `Error` :
+    - Ex: Don’t write `EmptyArrayException`, write `EmptyArray`
 
 ## **Testing**
 
 - Avoid usage of `should` each time you are writing an `it` statement.
-    - Ex: Don’t write `it('should run successfully'`), write `it('runs successfully')`.
+  - Ex: Don’t write `it('should run successfully'`), write `it('runs successfully')`.
 
 ### **Key points:**
 
 1. **Purpose of Tests**:
-    1. Use tests to clearly state the expected behavior for core business scenarios. Well-written tests can often be more clarifying than code comments.
+   1. Use tests to clearly state the expected behavior for core business scenarios. Well-written tests can often be more clarifying than code comments.
 2. **Mindset**:
-    1. Approach testing with the mindset of, "I've considered how this situation impacts the business and I expect the code to behave as indicated by the test." This confirms that the implemented code functions as intended.
+   1. Approach testing with the mindset of, "I've considered how this situation impacts the business and I expect the code to behave as indicated by the test." This confirms that the implemented code functions as intended.
 3. **Efficiency**:
-    1. Avoid blind testing, which is time-consuming. Instead, focus on testing the most critical business scenarios.
-    2. For example, if the business cares about a scenario where an action as a consequence of one of many sub-actions (Promise all for example) , write a test that expects failure when any operation fails. This approach efficiently communicates the expected behavior.
+   1. Avoid blind testing, which is time-consuming. Instead, focus on testing the most critical business scenarios.
+   2. For example, if the business cares about a scenario where an action as a consequence of one of many sub-actions (Promise all for example) , write a test that expects failure when any operation fails. This approach efficiently communicates the expected behavior.
 4. **Clarity:**
-    1. Aim for a test suite that clearly indicates the intended behavior of the code. Reading the test results should provide a clear understanding of what the code is supposed to do.
+   1. Aim for a test suite that clearly indicates the intended behavior of the code. Reading the test results should provide a clear understanding of what the code is supposed to do.
 
 ## **Scripting**
 
@@ -102,11 +101,11 @@ If we look at it from composability a `Service` can be made up of `Providers` an
 
 - Use `process.cwd()` to reference the root directory within scripts.
 - Organize scripts in the `package.json` file using the format:
-    - Infrastructure scripts: `script:infra:{name}`
-    - Utility scripts: `script:util:{name}`
+  - Infrastructure scripts: `script:infra:{name}`
+  - Utility scripts: `script:util:{name}`
 - Create a `scripts` folder with the following structure:
-    - `infra/` for infrastructure scripts.
-    - `utilities/` for utility scripts.
+  - `infra/` for infrastructure scripts.
+  - `utilities/` for utility scripts.
 
 ### **Package Management**
 

--- a/sites/wonderland/docs/development/offchain/onboarding/challenge.md
+++ b/sites/wonderland/docs/development/offchain/onboarding/challenge.md
@@ -38,7 +38,7 @@ Create the challenge repo using the [Wonder's Repo Creator](https://github.com/d
   - Utilize monorepo template
 - Pricing Module:
   - Fetch prices from Coingecko and DeFiLlama
-  - Implement [factory pattern](https://refactoring.guru/design-patterns/singleton) for provider selection
+  - Implement [factory pattern](https://refactoring.guru/design-patterns/factory-method) for provider selection
   - Add caching with 60-second TTL
 - Logger:
   - Implement using [singleton pattern](https://refactoring.guru/design-patterns/singleton)

--- a/sites/wonderland/docs/development/research/onboarding/challenges/defi/defi.md
+++ b/sites/wonderland/docs/development/research/onboarding/challenges/defi/defi.md
@@ -1,7 +1,8 @@
 # DeFi
+
 ## Understanding Protocol Dynamics
 
-This challenge consists of three stages, each focused on a key area of DeFi: interest rates in lending protocols, fee dynamics in AMMs, and AMM design comparisons. You’ll analyze, calculate and provide insights into how these protocols function and impact users. 
+This challenge consists of three stages, each focused on a key area of DeFi: interest rates in lending protocols, fee dynamics in AMMs, and AMM design comparisons. You’ll analyze, calculate and provide insights into how these protocols function and impact users.
 
 ## Stage 1: Interest Rate Analysis in Aave
 
@@ -21,9 +22,9 @@ Using the provided Aave interest rate contract, analyze how changes to interest 
 **Parameter Adjustments:**
 
 - Scenario 1: Increase the `baseVariableBorrowRate` by 1%.
-    - What happens to borrowing costs for low-utilization levels?
+  - What happens to borrowing costs for low-utilization levels?
 - Scenario 2: Double the `variableRateSlope2`.
-    - How does this impact borrowers and lenders when utilization exceeds the `optimalUsageRatio`?
+  - How does this impact borrowers and lenders when utilization exceeds the `optimalUsageRatio`?
 
 **Impact Assessment:**
 
@@ -34,9 +35,9 @@ Using the provided Aave interest rate contract, analyze how changes to interest 
 **Technical Analysis:**
 
 - **Review the contract** and explain how the following functions are used to calculate interest rates dynamically:
-    - `calculateInterestRates`: Adjusts rates based on current liquidity and debt levels.
-    - `getVariableRateSlope1` and `getVariableRateSlope2`: Retrieves the slope parameters for variable rates.
-    - `getBaseVariableBorrowRate`: Provides the base borrowing cost.
+  - `calculateInterestRates`: Adjusts rates based on current liquidity and debt levels.
+  - `getVariableRateSlope1` and `getVariableRateSlope2`: Retrieves the slope parameters for variable rates.
+  - `getBaseVariableBorrowRate`: Provides the base borrowing cost.
 
 **Deliverables:**
 
@@ -47,30 +48,30 @@ Using the provided Aave interest rate contract, analyze how changes to interest 
 
 - **Read the Contract**: Focus on the `calculateInterestRates` function to understand how the protocol dynamically adjusts rates based on utilization. Pay attention to how `supplyUsageRatio` and `borrowUsageRatio` are calculated and used.
 - **Define Assumptions**
-    - Example values for `optimalUsageRatio`, `slope1`, and `slope2` can help anchor your analysis.
-    - Assume realistic utilization rates (e.g., 50%, 80%, and 100%) to test your scenarios.
+  - Example values for `optimalUsageRatio`, `slope1`, and `slope2` can help anchor your analysis.
+  - Assume realistic utilization rates (e.g., 50%, 80%, and 100%) to test your scenarios.
 
 ## Stage 2: Comparing AMMs — Uniswap V2 vs. Curve StableSwap
 
-We already learned in [How an AMM works](https://www.notion.so/How-an-AMM-works-1829a4c092c780aea69acee2bbf29d95?pvs=21) that AMMs use different curve designs to optimize for specific use cases. The challenge in this stage is to compare the efficiency and behaviour of Uniswap V2 and curve StableSwap for a stable pair (e.g USDC/DAI) by answering:
+We already learned in [How an AMM works](https://handbook.wonderland.xyz/docs/development/research/onboarding/knowledge-base/defi/amm) that AMMs use different curve designs to optimize for specific use cases. The challenge in this stage is to compare the efficiency and behaviour of Uniswap V2 and curve StableSwap for a stable pair (e.g USDC/DAI) by answering:
 
-1. Swap cost comparison: 
-    1. Calculate the cost of swapping:
-        1. 1000 of USDC/DAI
-        2. 10000 of USDC/DAI
-    2. Compare these costs on:
-        1. Uni V2
-        2. StableSwap
-    3. Analyze the differences in slippage and swap efficiency for both protocols 
+1. Swap cost comparison:
+   1. Calculate the cost of swapping:
+      1. 1000 of USDC/DAI
+      2. 10000 of USDC/DAI
+   2. Compare these costs on:
+      1. Uni V2
+      2. StableSwap
+   3. Analyze the differences in slippage and swap efficiency for both protocols
 2. Liquidity Efficiency:
-    1. Analyze how liquidity is distributed along the curve in:
-        1. Uniswap V2
-        2. StableSwap
-    2. Discuss which design is more efficient for stable pairs and why. 
-3. Scenario Analysis: 
-    1. Assume the trading volume increases significantly in both protocols. Explain how the behaviour of swap costs and efficiency changes as liquidity is added or removed in:
-        1. Uni V2
-        2. StableSwap
+   1. Analyze how liquidity is distributed along the curve in:
+      1. Uniswap V2
+      2. StableSwap
+   2. Discuss which design is more efficient for stable pairs and why.
+3. Scenario Analysis:
+   1. Assume the trading volume increases significantly in both protocols. Explain how the behaviour of swap costs and efficiency changes as liquidity is added or removed in:
+      1. Uni V2
+      2. StableSwap
 
 **Deliverables**
 
@@ -85,38 +86,38 @@ The main improvement within UniswapV3 is that of higher capital efficiency via c
 ### **1. Bonding Curve Construction:**
 
 - **Understanding the Uniswap V3 Bonding Curve:**
-    - The mathematical structure behind liquidity concentration.
-    - How price moves along the curve when liquidity is highly concentrated.
+  - The mathematical structure behind liquidity concentration.
+  - How price moves along the curve when liquidity is highly concentrated.
 - **Examples of LP Positions:**
-    - Single-range position: An LP providing liquidity in a tight price range.
-    - Multi-range position: LPs splitting capital across multiple price bands.
-    - Wide-range position: LPs covering a broader price spectrum for passive strategies.
+  - Single-range position: An LP providing liquidity in a tight price range.
+  - Multi-range position: LPs splitting capital across multiple price bands.
+  - Wide-range position: LPs covering a broader price spectrum for passive strategies.
 - **Aggregating LP Positions:**
-    - How different LP positions interact to form the global liquidity curve.
-    - Example calculations of how liquidity depth changes based on LP distributions.
+  - How different LP positions interact to form the global liquidity curve.
+  - Example calculations of how liquidity depth changes based on LP distributions.
 
 ### **2. Mathematical Implications:**
 
 - **Price Curve Adjustments:**
-    - How concentrated liquidity affects the swap price curve compared to V2.
-    - Formula adjustments for slippage and price impact.
+  - How concentrated liquidity affects the swap price curve compared to V2.
+  - Formula adjustments for slippage and price impact.
 - **Capital Efficiency Improvements:**
-    - Estimating how much capital is needed in V3 vs. V2 for similar depth.
-    - Practical calculations of how liquidity concentration reduces slippage.
+  - Estimating how much capital is needed in V3 vs. V2 for similar depth.
+  - Practical calculations of how liquidity concentration reduces slippage.
 - **Napkin Math for Expected Swap Costs:**
-    - Approximate trade cost differences between V3 and V2 for various trade sizes.
+  - Approximate trade cost differences between V3 and V2 for various trade sizes.
 
 ### **3. Scenario Analysis:**
 
 - **Small vs. Large Trades:**
-    - How V3 handles different trade sizes compared to V2.
-    - Effect of concentrated liquidity when price approaches LP range limits.
+  - How V3 handles different trade sizes compared to V2.
+  - Effect of concentrated liquidity when price approaches LP range limits.
 - **Impact on LP Revenue:**
-    - Differences in fee earnings for LPs in V3 vs. V2.
-    - The tradeoff between higher capital efficiency and the need for active management.
+  - Differences in fee earnings for LPs in V3 vs. V2.
+  - The tradeoff between higher capital efficiency and the need for active management.
 - **Adaptation of Strategies:**
-    - How arbitrageurs and market makers adjust their strategies in V3.
-    - The potential for dynamic fee adjustments with Uniswap V3’s new features.
+  - How arbitrageurs and market makers adjust their strategies in V3.
+  - The potential for dynamic fee adjustments with Uniswap V3’s new features.
 
 ### **Deliverables:**
 

--- a/sites/wonderland/docs/development/research/onboarding/knowledge-base/core/evm.md
+++ b/sites/wonderland/docs/development/research/onboarding/knowledge-base/core/evm.md
@@ -1,18 +1,18 @@
 # Ethereum Core
 
 :::tip
-We strongly recommend you to dive into the core concepts listed [here](https://inevitableeth.com/en/home/concepts) before diving into how Ethereum works. 
+We strongly recommend you to dive into the core concepts listed [here](https://inevitableeth.com/en/home/concepts) before diving into how Ethereum works.
 :::
 
 There are many ways to explain Ethereum—how it works, what it enables, and the key standards that define it. However, we believe the best place to start is with its ethos.
 
-It is often described as a trustless world computer— a shared, decentralized platform where participants can execute code, exchange value, and collaborate without needing central intermediaries. As you probably know, unlike first-generation blockchains that focus on simple value transfers, Ethereum's main innovation is its **programmability**: through *smart contracts*, participants can encode arbitrary logic that runs deterministically across a global network of nodes.
+It is often described as a trustless world computer— a shared, decentralized platform where participants can execute code, exchange value, and collaborate without needing central intermediaries. As you probably know, unlike first-generation blockchains that focus on simple value transfers, Ethereum's main innovation is its **programmability**: through _smart contracts_, participants can encode arbitrary logic that runs deterministically across a global network of nodes.
 
 The core motivation is to generalize Bitcoin's concept of a decentralized ledger into a [**Turing-complete platform**](https://en.wikipedia.org/wiki/Turing_completeness#:~:text=In%20colloquial%20usage%2C%20the%20terms,purpose%20computer%20or%20computer%20language.). By abstracting the ledger into a robust, distributed state machine, Ethereum extends the blockchain paradigm far beyond payment use cases.
 
 At its core, Ethereum consists of three main components:
 
-1. [**The Ethereum Virtual Machine (EVM)**](https://www.notion.so/Ethereum-Core-1ac9a4c092c78009ae48c59fef656503?pvs=21) – the decentralized execution environment.
+1. [**The Ethereum Virtual Machine (EVM)**](https://handbook.wonderland.xyz/docs/development/research/onboarding/knowledge-base/core/evm#the-evm) – the decentralized execution environment.
 2. **The Blockchain** – the shared ledger securing transactions and state changes.
 3. **The Network** – the global peer-to-peer infrastructure that keeps Ethereum running.
 
@@ -24,11 +24,11 @@ For reference on the historical side, we encourage you to read https://inevitabl
 
 ## The EVM
 
-The *brain* of Ethereum. The EVM is a specialized, stack-based execution environment that runs the [smart contracts](https://ethereum.org/en/developers/docs/smart-contracts/) trustlessly on every node. It's deterministic: given the same input state and instructions, it always produces the same result.
+The _brain_ of Ethereum. The EVM is a specialized, stack-based execution environment that runs the [smart contracts](https://ethereum.org/en/developers/docs/smart-contracts/) trustlessly on every node. It's deterministic: given the same input state and instructions, it always produces the same result.
 
-It has a **Stack-based architecture** because each contract invocation operates in an isolated EVM instance, which uses a [256-bit word](https://en.wikipedia.org/wiki/256-bit_computing), [LIFO stack](https://www.geeksforgeeks.org/lifo-last-in-first-out-approach-in-programming/) as its primary data structure. All operations consume operands from the top of the stack and push results back onto it. 
+It has a **Stack-based architecture** because each contract invocation operates in an isolated EVM instance, which uses a [256-bit word](https://en.wikipedia.org/wiki/256-bit_computing), [LIFO stack](https://www.geeksforgeeks.org/lifo-last-in-first-out-approach-in-programming/) as its primary data structure. All operations consume operands from the top of the stack and push results back onto it.
 
-Also, we will differentiate between memory and storage. The first one is volatile, and transient across execution. Measured in bytes, allocated in 32-byte chunks, it is freed after code execution. While the second one is persistent, a 32-byte key-value store unique to each contract address. Written changes remain across transactions. 
+Also, we will differentiate between memory and storage. The first one is volatile, and transient across execution. Measured in bytes, allocated in 32-byte chunks, it is freed after code execution. While the second one is persistent, a 32-byte key-value store unique to each contract address. Written changes remain across transactions.
 
 :::info
 Both memory and storage cost gas, but storage writes are significantly more expensive because they're committed to chain state.
@@ -37,11 +37,11 @@ Both memory and storage cost gas, but storage writes are significantly more expe
 The EVM supports around 150+ opcodes as described in the [Yellow Paper](https://ethereum.github.io/yellowpaper/paper.pdf). Each opcode has a defined gas cost. Some rely on environment data, while others manipulate the stack or contract state.
 
 :::tip
-**Deeper Dive:** 
+**Deeper Dive:**
 
-- [learnevm](https://www.notion.so/Ethereum-Core-1ac9a4c092c78009ae48c59fef656503?pvs=21) offers opcode-by-opcode explanations and hands-on examples.
-- *Mastering Ethereum* (Chapter 8 & 9) shows how contracts translate into EVM bytecode, with practical dev insights.
-:::
+- [learnevm](https://learnevm.com/chapters/intro/overview) offers opcode-by-opcode explanations and hands-on examples.
+- _Mastering Ethereum_ (Chapter 8 & 9) shows how contracts translate into EVM bytecode, with practical dev insights.
+  :::
 
 You might be asking: why should I care? And the answer is that a good mental model of the EVM's fundamentals is really important for you to design protocols that rely on EVM-friendly patterns.
 
@@ -53,33 +53,31 @@ You might be asking: why should I care? And the answer is that a good mental mod
 
 **Gas Limit and Fees:** A transaction specifies a gas limit (how much the sender is willing to spend—. Unused gas is refunded, but if execution runs out of gas, all state changes revert (an OOG —Out of Gas— exception). — You should check out the [EIP-1559](https://github.com/ethereum/EIPs/blob/master/EIPS/eip-1559.md) that introduced a base fee that is burned + a priority fee that goes to block proposers.
 
-**Block-Level Constraints:**  Each block has a **gas limit** (now effectively a "gas target" times an elasticity multiplier). Overly complex transactions might use the entire block's gas allotment, limiting throughput. The base fee is then adjusted from block to block to keep average consumption near a target.
+**Block-Level Constraints:** Each block has a **gas limit** (now effectively a "gas target" times an elasticity multiplier). Overly complex transactions might use the entire block's gas allotment, limiting throughput. The base fee is then adjusted from block to block to keep average consumption near a target.
 
 :::tip
-**Further Reading:** 
+**Further Reading:**
 
 - Mastering Ethereum explains how gas influences contract design, especially with patterns like **optimizing for minimal SSTORE usage — See Chapter 13**
 - The [Ethereum Gitbook](https://cypherpunks-core.github.io/ethereumbook/02intro.html) covers real-world examples of gas optimization in DeFi or NFT minting contracts.
-:::
+  :::
 
 ### Contracts
 
-Contracts in Ethereum are not *"launched and run somewhere else"*—they are **deployed** to the EVM, then **invoked** by transactions or message calls. Let's break this down:
+Contracts in Ethereum are not _"launched and run somewhere else"_—they are **deployed** to the EVM, then **invoked** by transactions or message calls. Let's break this down:
 
 - **Contract Creation**
-    - A special transaction with `to = null` is used to deploy code.
-    - During creation, an **init code** segment runs to set up the contract's storage or code. The final code is then stored at the address.
-        
-        We recommend you to watch this video : ) 👇
-        
-        https://www.youtube.com/watch?v=_tcyI_lNvo0
-        
+  - A special transaction with `to = null` is used to deploy code.
+  - During creation, an **init code** segment runs to set up the contract's storage or code. The final code is then stored at the address.
+    We recommend you to watch this video : ) 👇
+    https://www.youtube.com/watch?v=_tcyI_lNvo0
 - **Message Calls**
-    - When an externally owned account (EOA) or another contract calls a contract, the EVM executes the runtime bytecode.
-    - Contracts can call other contracts, forming complex interactions.
+  - When an externally owned account (EOA) or another contract calls a contract, the EVM executes the runtime bytecode.
+  - Contracts can call other contracts, forming complex interactions.
 - **Deterministic & Atomic**
-    - Any changes to contract storage only finalize if **no** exceptions (including OOG) occur. Otherwise the state reverts.
-    - This atomic, all-or-nothing approach is fundamental for building robust, predictable decentralized protocols.
+
+  - Any changes to contract storage only finalize if **no** exceptions (including OOG) occur. Otherwise the state reverts.
+  - This atomic, all-or-nothing approach is fundamental for building robust, predictable decentralized protocols.
 
 - **The [Yellow Paper, sec. 7 & 8](https://ethereum.github.io/yellowpaper/paper.pdf) —** Formal definitions of contract creation, message calls, and how code executes step by step.
 - [Mastering Ethereum](https://wiki.anomalous.xyz/pdfs/mastering-ethereum.pdf), Chapter 6 and Chapter 7, show applied examples (ERC-20).
@@ -98,9 +96,9 @@ SSTORE
 - **Gas Implications**: Storing a non-zero value in an empty slot costs significantly more (20,000 gas pre-London adjustments) than updating a slot from non-zero to another non-zero.
 - **Memory vs. Storage**: If a contract just needs data during execution, storing it in **memory** is cheaper. But for cross-transaction persistence, you need **storage**.
 
-For a deeper discussion of how these operations are priced, see the Appendix G in the *Yellow Paper* or [learnevm's Working with Memory and Storage.](https://learnevm.com/chapters/evm/memory)
+For a deeper discussion of how these operations are priced, see the Appendix G in the _Yellow Paper_ or [learnevm's Working with Memory and Storage.](https://learnevm.com/chapters/evm/memory)
 
-This was a short introduction, we encorage you to read https://cypherpunks-core.github.io/ethereumbook/13evm.html and the references that have been attached.  
+This was a short introduction, we encorage you to read https://cypherpunks-core.github.io/ethereumbook/13evm.html and the references that have been attached.
 
 ## The Blockchain
 
@@ -108,7 +106,7 @@ This was a short introduction, we encorage you to read https://cypherpunks-core.
 
 At its heart, Ethereum is a **transaction-based state machine**. Each transaction modifies a global state (balances, storage, etc.), and blocks group these transactions in an orderly sequence.
 
-**State Evolves Block by Block:** Each block includes a set of valid transactions, and the network collectively "*"executes*" these on top of the previous state to arrive at a new state. [Mastering Ethereum](https://wiki.anomalous.xyz/pdfs/mastering-ethereum.pdf) (Ch. 4 & 5) and the [Ethereum Gitbook](https://cypherpunks-core.github.io/ethereumbook/02intro.html) detail how balances, contract storage, and code get updated deterministically.
+**State Evolves Block by Block:** Each block includes a set of valid transactions, and the network collectively "_"executes_" these on top of the previous state to arrive at a new state. [Mastering Ethereum](https://wiki.anomalous.xyz/pdfs/mastering-ethereum.pdf) (Ch. 4 & 5) and the [Ethereum Gitbook](https://cypherpunks-core.github.io/ethereumbook/02intro.html) detail how balances, contract storage, and code get updated deterministically.
 
 **Block Structure: a b**locks contain:
 
@@ -123,14 +121,14 @@ Understanding this state transition mechanism is key to analyzing **transaction 
 
 ### Consensus & Forks
 
-Historically, Ethereum started with **proof-of-work (PoW)**—similar to Bitcoin's approach—but later transitioned to **proof-of-stake (PoS)** via *The Merge*. This shift changed how blocks are proposed and finalized.
+Historically, Ethereum started with **proof-of-work (PoW)**—similar to Bitcoin's approach—but later transitioned to **proof-of-stake (PoS)** via _The Merge_. This shift changed how blocks are proposed and finalized.
 
 1. **Proof of Work to Proof of Stake**
-    - Under [PoW](https://youtu.be/bBC-nXj3Ng4?t=870), miners expended computational resources solving cryptographic challenges, securing the chain in return for block rewards.
-    - Under PoS, *validators* lock up ether as stake and are randomly selected to propose blocks. Honest participation is rewarded; malicious activity can cause slashing of stake.
+   - Under [PoW](https://youtu.be/bBC-nXj3Ng4?t=870), miners expended computational resources solving cryptographic challenges, securing the chain in return for block rewards.
+   - Under PoS, _validators_ lock up ether as stake and are randomly selected to propose blocks. Honest participation is rewarded; malicious activity can cause slashing of stake.
 2. **Forks & Upgrades**
-    - Ethereum uses *hard forks* (e.g., [Homestead](https://github.com/ethereum/homestead-guide/blob/master/source/introduction/the-homestead-release.rst), [Byzantium](https://github.com/ethereum/wiki/wiki/Byzantium-Hard-Fork-changes), London) to upgrade protocol rules.
-    - Some forks have been contentious (like the DAO fork). *The Merge* itself was a major overhaul, switching out the PoW engine for PoS while keeping the EVM and accounts layer intact.
+   - Ethereum uses _hard forks_ (e.g., [Homestead](https://github.com/ethereum/homestead-guide/blob/master/source/introduction/the-homestead-release.rst), London) to upgrade protocol rules.
+   - Some forks have been contentious (like the DAO fork). _The Merge_ itself was a major overhaul, switching out the PoW engine for PoS while keeping the EVM and accounts layer intact.
 
 :::tip
 See https://inevitableeth.com/home/ethereum/network/consensus/PoW-vs-PoS for reference.
@@ -146,28 +144,28 @@ We need to discover nodes, right? For doing that, Ethereum relies on the devp2p 
 
 1. Node Discovery: Uses a kademlia-like protocol (UDP based) to find peers. Once discovered, a node's identity and capabilities are exchanged, so others know which subprotocols you support.
 2. Peer connections & devp2p RLPx: After discovery, nodes set up an encrypted TCP session using RLPx, with ephemeral key exchange.
-    
-    They will do a handshake, exchanging a Hello —or *Status*— message. EIP-8 ensures that version mismatches or extra list elements do not break the handshake — older nodes can interoperate with newer devp2p versions.
-    
-    The handshake and subsequent devp2p messages are encoded in RLP (Recursive Length Prefix). Extra fields or new versions can be gracefully ignored if the node doesn't recognize them.
+
+   They will do a handshake, exchanging a Hello —or _Status_— message. EIP-8 ensures that version mismatches or extra list elements do not break the handshake — older nodes can interoperate with newer devp2p versions.
+
+   The handshake and subsequent devp2p messages are encoded in RLP (Recursive Length Prefix). Extra fields or new versions can be gracefully ignored if the node doesn't recognize them.
 
 :::info
 **Ref. [EIP-8](https://github.com/ethereum/EIPs/blob/master/EIPS/eip-8.md)** – Explains the relaxed decoding rules for devp2p "hello" packets, RLPx discovery, and ephemeral key negotiation. This approach was critical for pushing future upgrades like RLPx v5 without fracturing the network.
 :::
 
-1. Message Gossiping: once the handshake completes, nodes gossip new transactions, blocks, receipts, etc. as part of the eth subprotocol. So that the entire network quickly sees fresh data and coverages on a canonical chain. 
+1. Message Gossiping: once the handshake completes, nodes gossip new transactions, blocks, receipts, etc. as part of the eth subprotocol. So that the entire network quickly sees fresh data and coverages on a canonical chain.
 
 ### Client Diversity
 
 **As you probably know, clients a**re software implementations that speak the protocol's rules. Having multiple clients fosters resilience against bugs and centralization:
 
 - **Prominent Clients**
-    - **Geth** (Go-Ethereum) – Historically the most used.
-    - **Prysm, Lighthouse, Teku** – Clients for the PoS consensus layer (Beacon chain).
-    - **Nethermind**, **Besu**, and (formerly) **OpenEthereum** – Additional choices with various performance trade-offs.
+  - **Geth** (Go-Ethereum) – Historically the most used.
+  - **Prysm, Lighthouse, Teku** – Clients for the PoS consensus layer (Beacon chain).
+  - **Nethermind**, **Besu**, and (formerly) **OpenEthereum** – Additional choices with various performance trade-offs.
 - **Why Multiple Clients?**
-    - A single reference client (like "Bitcoin Core") can become a single point of failure.
-    - If one client's implementation has a consensus bug, others might reject it, preventing chain-wide meltdown.
+  - A single reference client (like "Bitcoin Core") can become a single point of failure.
+  - If one client's implementation has a consensus bug, others might reject it, preventing chain-wide meltdown.
 
 :::info
 Deeper info in https://cypherpunks-core.github.io/ethereumbook/03clients.html
@@ -188,8 +186,8 @@ When you first run an Ethereum client, it **syncs** from the genesis block to th
 Ethereum's approach to protocol evolution includes **hard forks**:
 
 - **Block number or TTD triggers**
-    - e.g., "Byzantium" fork at block 4,370,000 (PoW era).
-    - *The Merge* triggered by the Terminal Total Difficulty (TTD) instead of block number.
+  - e.g., "Byzantium" fork at block 4,370,000 (PoW era).
+  - _The Merge_ triggered by the Terminal Total Difficulty (TTD) instead of block number.
 - **Backward-incompatible changes** require node upgrades. Non-upgraded nodes follow the old chain, forming a fork if there's disagreement (like the classic "DAO fork").
 
 ### Takeaways
@@ -200,7 +198,7 @@ So, as a takeaway, the network can be seen as the "circulatory system," it carri
 - Evaluate finality times or block distribution for advanced protocols.
 - Explore how L2 or cross-chain solutions integrate at the node level.
 
-With the EVM, the blockchain, and the network under your belt, the next step is to examine **the standards**—EIPs and ERCs—that unify development practices and enable new functionalities across the Ethereum ecosystem. 
+With the EVM, the blockchain, and the network under your belt, the next step is to examine **the standards**—EIPs and ERCs—that unify development practices and enable new functionalities across the Ethereum ecosystem.
 
 ## The EIPs
 
@@ -219,20 +217,20 @@ Ethereum Improvement Proposals are the way we propose protocol upgrades, applica
 An EIP typically moves through these stages:
 
 1. **Idea**
-    - Start with a concept in mind (maybe you want to propose a new cross-chain protocol).
-    - You share an overview on forums like [Ethereum Magicians](https://ethereum-magicians.org/) to gather support and feedback.
+   - Start with a concept in mind (maybe you want to propose a new cross-chain protocol).
+   - You share an overview on forums like [Ethereum Magicians](https://ethereum-magicians.org/) to gather support and feedback.
 2. **Draft**
-    - Once you have minimal consensus that this is viable, you create or finalize a PR in the [EIPs GitHub repo](https://github.com/ethereum/EIPs).
-    - An EIP editor merges it, assigns it an official EIP number, and your proposal is now tracked as a draft.
+   - Once you have minimal consensus that this is viable, you create or finalize a PR in the [EIPs GitHub repo](https://github.com/ethereum/EIPs).
+   - An EIP editor merges it, assigns it an official EIP number, and your proposal is now tracked as a draft.
 3. **Review**
-    - The EIP is refined publicly, with the community (and EIP editors) giving feedback for at least 45 days.
-    - If it gains traction and thorough discussion, an editor can move it to **Last Call**.
+   - The EIP is refined publicly, with the community (and EIP editors) giving feedback for at least 45 days.
+   - If it gains traction and thorough discussion, an editor can move it to **Last Call**.
 4. **Last Call**
-    - The final chance for any major change. Typically lasts 14 days unless there's a substantial revision.
-    - If no major objection arises, the EIP can be marked **Final**.
+   - The final chance for any major change. Typically lasts 14 days unless there's a substantial revision.
+   - If no major objection arises, the EIP can be marked **Final**.
 5. **Final**
-    - Means "it's done on paper." For a **Core** EIP, being Final does **not** guarantee immediate activation on the network. Instead, it often waits for an upcoming upgrade (fork) that includes it.
-    - Some EIPs remain "finalized" only on an application level (e.g., an ERC standard that dApps can optionally adopt).
+   - Means "it's done on paper." For a **Core** EIP, being Final does **not** guarantee immediate activation on the network. Instead, it often waits for an upcoming upgrade (fork) that includes it.
+   - Some EIPs remain "finalized" only on an application level (e.g., an ERC standard that dApps can optionally adopt).
 
 Additionally:
 
@@ -241,7 +239,7 @@ Additionally:
 - **Living**: A special permanent-draft status for "evergreen" EIPs like EIP-1.
 
 :::tip
-It is *super* useful to be updated with the EIPs, for doing that, we recommend you check out [EIPs.wtf](https://www.eips.wtf/), [EIP.Fun](http://EIP.Fun) and [EIPs Insight](https://eipsinsight.com/). Also, if interested in discussing, you should refer to [Ethereum Magicians Forum](https://ethereum-magicians.org/) —it is the primary place to discuss EIPs with other devs/researchers.
+It is _super_ useful to be updated with the EIPs, for doing that, we recommend you check out [EIPs.wtf](https://www.eips.wtf/), [EIP.Fun](http://EIP.Fun) and [EIPs Insight](https://eipsinsight.com/). Also, if interested in discussing, you should refer to [Ethereum Magicians Forum](https://ethereum-magicians.org/) —it is the primary place to discuss EIPs with other devs/researchers.
 :::
 
 ### Who Oversees EIPs?
@@ -253,7 +251,7 @@ It is *super* useful to be updated with the EIPs, for doing that, we recommend y
 
 #### **EIP-1559** – London Upgrade (August 2021)
 
-It overhauled the fee market by introducing a *base fee* that is burned, plus a *priority fee* to block proposers. Aims to reduce fee volatility, make gas pricing more predictable, and partially offset ETH issuance by burning fees. The key features were:
+It overhauled the fee market by introducing a _base fee_ that is burned, plus a _priority fee_ to block proposers. Aims to reduce fee volatility, make gas pricing more predictable, and partially offset ETH issuance by burning fees. The key features were:
 
 - Transaction "max fee" and "max priority fee" replaced the old single gasPrice model.
 - Introduced block elasticity mechanism, so blocks can handle short congestion spikes.
@@ -276,9 +274,9 @@ See https://eips.ethereum.org/EIPS/eip-779
 
 #### **EIP-7** – `DELEGATECALL` Introduction (late 2015)
 
-`DELEGATECALL` replaced the older `CALLCODE` opcode, addressing issues where `CALLCODE` didn't preserve `msg.sender` or `msg.value` as the *original* caller. This was a key enabler for proxy contract patterns, libraries, and composable "logic & data" separation. The important things are that:
+`DELEGATECALL` replaced the older `CALLCODE` opcode, addressing issues where `CALLCODE` didn't preserve `msg.sender` or `msg.value` as the _original_ caller. This was a key enabler for proxy contract patterns, libraries, and composable "logic & data" separation. The important things are that:
 
-- Code is called in the *context* of the current contract.
+- Code is called in the _context_ of the current contract.
 - `msg.sender` remains the original caller, enabling advanced patterns like "upgradeable proxies."
 
 :::info
@@ -287,7 +285,7 @@ See https://ethereum.stackexchange.com/questions/3667/difference-between-call-ca
 
 #### **EIP-1014** – `CREATE2` Opcode (2019)
 
-- **Why Important**Introduced a new way to compute a contract's address before it's deployed, using `create2`. This helps in "counterfactual" contract deployments, where you can *reserve* an address in advance, which is vital in meta-transactions or on-chain address commitments.
+- **Why Important**Introduced a new way to compute a contract's address before it's deployed, using `create2`. This helps in "counterfactual" contract deployments, where you can _reserve_ an address in advance, which is vital in meta-transactions or on-chain address commitments.
 - Address formula is $$keccak256(0xFF, sender, salt, code)$$ all known at creation time.
 - Allows advanced patterns in DeFi, state channels, "factory" contracts, etc.
 
@@ -305,8 +303,7 @@ See https://eips.ethereum.org/EIPS/eip-3675
 
 ## The ERCs
 
-Ethereum Request for Comments are a subset of EIPs that define **standards for applications, pr**imarily around tokens and smart contract interfaces. They ensure that different dApps, wallets, and contracts can interact with each other without drama.  We encourage you to dive into the most popular ones in https://eips.ethereum.org/erc.
-
+Ethereum Request for Comments are a subset of EIPs that define **standards for applications, pr**imarily around tokens and smart contract interfaces. They ensure that different dApps, wallets, and contracts can interact with each other without drama. We encourage you to dive into the most popular ones in https://eips.ethereum.org/erc.
 
 **Now… is time to check the resources! This is just an overview, Ethereum is way to broad to explain in one document. And most importantly: ask questions!**
 

--- a/sites/wonderland/docs/development/research/onboarding/knowledge-base/core/oracles.md
+++ b/sites/wonderland/docs/development/research/onboarding/knowledge-base/core/oracles.md
@@ -57,7 +57,7 @@ While many DeFi users trust solutions like Chainlink or Maker or rely on a Unisw
 The overarching moral is that conventional solutions work fine day to day but can run into serious issues during black swan events—those rare but cataclysmic moments of extreme volatility or abrupt market shifts. Oracles must be resilient enough to withstand those events if they are truly to be considered trust-minimized.
 
 :::info
-See https://defi.sucks/insights/rip-oracles
+See https://mirror.xyz/mirror.wonderland.xyz/7e4aTSNvhzEAYz_ZzRELz8ZV6iL1eqfOKSFUGoX-neo
 :::
 
 ## Price

--- a/sites/wonderland/docs/development/solidity/onboarding/challenges/security-challenges.md
+++ b/sites/wonderland/docs/development/solidity/onboarding/challenges/security-challenges.md
@@ -14,3 +14,5 @@ In this section of the onboarding, our goal is to familiarize you with the most 
 6. [Ludopathy](https://github.com/defi-wonderland/security-onboarding/tree/dev/solidity/challenges/medium/Ludopathy)
 7. [GeistHeist](https://github.com/defi-wonderland/security-onboarding/tree/dev/solidity/challenges/medium/GeistHeist)
 8. [Arcanery](https://github.com/defi-wonderland/security-onboarding/tree/dev/solidity/challenges/medium/Arcanery)
+
+> ⚠️ **Note:** These challenges are private for now; [follow us](https://x.com/DeFi_Wonderland) to stay updated on the handbook's evolution

--- a/sites/wonderland/docs/outro/contribute.md
+++ b/sites/wonderland/docs/outro/contribute.md
@@ -14,11 +14,13 @@ This is our shared craft. We're constantly refining how we build, test, and coor
 We welcome contributions from everyone! Here's how you can help improve the handbook:
 
 1. **Open an Issue**
+
    - Found a bug? Have a suggestion? Open an issue on our GitHub repository
    - Clearly describe what could be improved and why
    - Tag the issue appropriately (documentation, enhancement, bug, etc.)
 
 2. **Submit a Pull Request**
+
    - Fork the repository
    - Create a new branch for your changes
    - Make your updates following our [documentation style guide](/docs/development/research/technical-writing)
@@ -26,6 +28,7 @@ We welcome contributions from everyone! Here's how you can help improve the hand
    - Link any related issues
 
 3. **Review Process**
+
    - All PRs will be reviewed by the team
    - Address any requested changes
    - Once approved, your contribution will be merged
@@ -38,10 +41,9 @@ We welcome contributions from everyone! Here's how you can help improve the hand
 
 Remember: The best handbooks grow with the team. Your insights and experience make this resource better for everyone.
 
-
 # Join the Team
 
-Want to build with us? Visit [apply.defi.sucks](https://apply.defi.sucks) to explore open roles ✨
+Want to build with us? Visit [apply.wonderland.xyz](https://apply.wonderland.xyz) to explore open roles ✨
 
 Stay safe. Build with care.  
 🌌 — Wonderland

--- a/sites/wonderland/docs/processes/github/ssh-setup.md
+++ b/sites/wonderland/docs/processes/github/ssh-setup.md
@@ -74,6 +74,7 @@ Test your connection:
 - **Windows (WSL)**
   No action required.
   (Optional) If you have multiple SSH keys within 1Password vaults you can edit its priority order by editing the `agent.toml` file located at `C:\Users\Mati\AppData\Local\1Password\config\ssh\agent.toml`
+
   ```bash
   # Wonderland Anon Github Token
   [[ssh-keys]]
@@ -87,8 +88,7 @@ Test your connection:
   vault = "Personal"
   account = "<THE_1PASSWORD_ACCOUNT_WHERE_YOU_HAVE_YOUR_PERSONAL_SSH>"
   ```
-  **Warning**: This doesn't allow you to use multiple keys for different host as mentioned in [https://www.notion.so/defi-wonderland/Git-and-SSH-Setup-with-1Password-22cf4135c7074898b95a4e88ac3e05c4?pvs=4#14c0bf386ef74c09b889b7cc85823af9](https://www.notion.so/Git-and-SSH-Setup-with-1Password-22cf4135c7074898b95a4e88ac3e05c4?pvs=21)
-  In this case, it is only useful for specifying the default ssh keys that 1Password will use.
+
 - **Mac / Linux**
   File: `~/.config/1Password/ssh/agent.toml`
   File: `~/.ssh/pub/personal_git.pub`

--- a/sites/wonderland/docs/security/multisig/safe-config.md
+++ b/sites/wonderland/docs/security/multisig/safe-config.md
@@ -1,22 +1,20 @@
 # Safe(ty) - Multisig Configuration
 
 :::tip
+
 - **DOs:**
-    - Ensure added signers increase security (e.g., 2/2 > 2/3 for safety).
-    - Use backups, sharding, or dead-man switches.
-    - Separate daily ops, treasury, and governance into distinct Safes.
-    - Regularly check for accuracy by proposing faulty transactions.
-    - Implement Guard Smart Contracts for transaction rules.
-    - Audit contracts and test in sandbox environments before mainnet.
-- **DO NOTs:**
-    - Rely on one Safe for all operations.
-    - Use delegate calls.
-    - Deploy without testing—always test configurations and contracts before going live.
-:::
+  - Ensure added signers increase security (e.g., 2/2 > 2/3 for safety).
+  - Use backups, sharding, or dead-man switches.
+  - Separate daily ops, treasury, and governance into distinct Safes.
+  - Regularly check for accuracy by proposing faulty transactions.
+  - Implement Guard Smart Contracts for transaction rules.
+  - Audit contracts and test in sandbox environments before mainnet.
+- **DO NOTs:** - Rely on one Safe for all operations. - Use delegate calls. - Deploy without testing—always test configurations and contracts before going live.
+  :::
 
 ## Addition of signers should INCREASE the operational safety of the multisig.
 
-Adding signers should enhance security rather than compromise it. 
+Adding signers should enhance security rather than compromise it.
 
 - A 2/2 safe is inherently more secure than a 2/3 safe, as the latter increases the attack surface—two of three signers are easier to compromise than two of two.
 
@@ -24,7 +22,7 @@ Adding signers should enhance security rather than compromise it.
 
 It must be impossible for a signer to lose their ability to sign. This can be achieved by any or a combination of the following methods:
 
-1. Sharding & Backup — read [Hardware Wallet Configuration](./hardware-requirements.md) 
+1. Sharding & Backup — read [Hardware Wallet Configuration](./hardware-requirements.md)
 2. Dead-Man Switch — Use bonded time-locked inactivity triggers or social recovery mechanisms. Trusted parties can reassign signer roles securely.
 
 :::tip
@@ -45,9 +43,9 @@ For instance:
 Currently, there is no built-in way to enforce this on-chain (via the official Safe app), but it is straightforward to build a **Guard Smart Contract** to enforce these "safety lanes."
 
 :::tip
-A **Guard Smart Contract** is a modular contract that enforces specific security rules for multisig operations. It acts as a protective layer for your multisig wallet, validating transactions and ensuring they conform to predefined safety parameters before execution. 
+A **Guard Smart Contract** is a modular contract that enforces specific security rules for multisig operations. It acts as a protective layer for your multisig wallet, validating transactions and ensuring they conform to predefined safety parameters before execution.
 
-This approach is often used with solutions like **Gnosis Safe**, which allows custom Guard contracts to be added. — Read https://docs.safe.global/advanced/smart-account-guards. 
+This approach is often used with solutions like **Gnosis Safe**, which allows custom Guard contracts to be added. — Read https://docs.safe.global/advanced/smart-account-guards.
 
 :::
 
@@ -60,31 +58,31 @@ This approach is often used with solutions like **Gnosis Safe**, which allows cu
 Pretty straightforward: **create a Safe without risks of frontrunning or duplication** while ensuring consistent functionality across chains. Multichain setups are crucial for organizations operating in diverse ecosystems, as they allow for seamless, secure transactions and governance. You can:
 
 1. **Self-Replication with Latest Security Settings**:
-    - The Safe should replicate itself across chains while adapting to changes in signers or parameters.
-    - Dynamically compute the **salt** (initialization code) to reflect the current state of the Safe (e.g., signer list, thresholds, and modules). This prevents conflicts or accidental duplication when deploying on new chains.
-    
+   - The Safe should replicate itself across chains while adapting to changes in signers or parameters.
+   - Dynamically compute the **salt** (initialization code) to reflect the current state of the Safe (e.g., signer list, thresholds, and modules). This prevents conflicts or accidental duplication when deploying on new chains.
+
 :::tip
-    Use the `CREATE2` opcode to deploy contracts with deterministic addresses. 
+Use the `CREATE2` opcode to deploy contracts with deterministic addresses.
 :::
-    
+
 :::tip
 The Safe UI is pretty good at addressing this, but it's important to verify whether security settings are consistently maintained across different chains when changes are made.
 :::
-    
+
 2. **Cross-chain module and guard compatibility:**
-    - Ensure that modules and guards are designed to function seamlessly across multiple chains.
-    - If chain-specific modules are required, they should adhere to a shared security framework to prevent vulnerabilities in a multichain setup.
-    
+   - Ensure that modules and guards are designed to function seamlessly across multiple chains.
+   - If chain-specific modules are required, they should adhere to a shared security framework to prevent vulnerabilities in a multichain setup.
+
 :::tip
-    Use modular architecture to allow easy upgrades or adjustments for chain-specific needs.
+Use modular architecture to allow easy upgrades or adjustments for chain-specific needs.
 :::
-    
+
 3. **Multichain Deployer Contract**:
-    - Create a **Multichain Deployer Contract**, owned by the original Safe, to handle deployments as trusted transactions.
-    - This contract:
-        - Tracks deployments across chains.
-        - Enforces uniform initialization parameters.
-        - Manages updates centrally for security and efficiency.
+   - Create a **Multichain Deployer Contract**, owned by the original Safe, to handle deployments as trusted transactions.
+   - This contract:
+     - Tracks deployments across chains.
+     - Enforces uniform initialization parameters.
+     - Manages updates centrally for security and efficiency.
 
 :::tip
 Treat multichain deployments as secure Safe transactions, requiring approvals or governance from the original Safe.
@@ -92,9 +90,9 @@ Treat multichain deployments as secure Safe transactions, requiring approvals or
 
 ## One safe to rule them all? NOT!
 
-You **should NOT** rely on a single Safe for *everything,* you'll just increase operational complexity and will most likely fuck-up. 
+You **should NOT** rely on a single Safe for _everything,_ you'll just increase operational complexity and will most likely fuck-up.
 
-You can use monthly allowances for piggy-bank operations, but ideally you should have these be set to a separate operational multisig, that has a different security profile. Basically, segment responsibilities into separate Safes: 
+You can use monthly allowances for piggy-bank operations, but ideally you should have these be set to a separate operational multisig, that has a different security profile. Basically, segment responsibilities into separate Safes:
 
 - **Operational Safes**: Small daily transactions.
 - **Treasury Safes**: Secure critical funds.
@@ -103,7 +101,7 @@ You can use monthly allowances for piggy-bank operations, but ideally you should
 Critical roles or access Safes should NOT double as treasuries. **Segmentation simplifies operations and reduces risk.**
 
 :::tip
-The use of security-focused/upgrade/management/payments multisigs might sound like a headache, but it's a MUST to keep shit simple, since you'll need periphery smart contracts and custom configs to make a Safe truly safe. 
+The use of security-focused/upgrade/management/payments multisigs might sound like a headache, but it's a MUST to keep shit simple, since you'll need periphery smart contracts and custom configs to make a Safe truly safe.
 :::
 
 ## Test your transaction reviewers constantly
@@ -113,7 +111,7 @@ Transaction reviewers are the first line of defense against faulty or malicious 
 - Test their vigilance by proposing incorrect data.
 - Rotate out reviewers who fail to catch issues to prevent a false sense of security
 
-Ideally, you'd setup bounties (or penalties) for catching faulty transactions. 
+Ideally, you'd setup bounties (or penalties) for catching faulty transactions.
 
 You should also propose some faulty data purposely to check if people are really watching, and rotate the ones that do not, since those will provide a false sense of security, which is a slow killer.
 
@@ -136,7 +134,5 @@ https://medium.com/gnosis-pm/formal-verification-a-journey-deep-into-the-gnosis-
 https://academy.binance.com/en/articles/threshold-signatures-explained
 
 https://empoweredlaw.wordpress.com/2014/05/25/multi-signature-accounts-for-corporate-governance/
-
-https://safehodl.github.io/multisig/
 
 https://forum.openzeppelin.com/t/list-of-solidity-libraries-in-the-wild/2250#heading--multisig

--- a/sites/wonderland/docs/testing/unit-integration.md
+++ b/sites/wonderland/docs/testing/unit-integration.md
@@ -6,7 +6,7 @@ Testing is everyone's responsibility at Wonderland. We do not merge pull request
 
 ## Unit test
 
-A "unit" is defined as the smallest piece of logic in a system. In a protocol built from smart contracts, we define functions as units. A unit test's purpose is to test the behaviour of this unit in every possible scenario. To do so, we isolate the unit by *mocking* any external dependencies (solitary testing), then study and test every *branch*. The number of branches tested is expressed as the test *coverage*. We'll explain these concepts and how we approach them at Wonderland.
+A "unit" is defined as the smallest piece of logic in a system. In a protocol built from smart contracts, we define functions as units. A unit test's purpose is to test the behaviour of this unit in every possible scenario. To do so, we isolate the unit by _mocking_ any external dependencies (solitary testing), then study and test every _branch_. The number of branches tested is expressed as the test _coverage_. We'll explain these concepts and how we approach them at Wonderland.
 
 ### Mocking
 
@@ -177,12 +177,12 @@ Coverage is a metric showing how much of our unit is actually "touched" by our t
 Every possible way to reach an end state is called a path. For our example, there are 4 paths with only 2 end states, which are the expression of the truth table of a^b (a AND b):
 
 ```markdown
-| A | B | A and B |
-|---|---|---------|
-| 0 | 0 |    0    |
-| 0 | 1 |    0    |
-| 1 | 0 |    0    |
-| 1 | 1 |    1    |
+| A   | B   | A and B |
+| --- | --- | ------- |
+| 0   | 0   | 0       |
+| 0   | 1   | 0       |
+| 1   | 0   | 0       |
+| 1   | 1   | 1       |
 ```
 
 ```mermaid
@@ -338,7 +338,7 @@ The coverage measures 'something' being touched by our tests. This something can
 
 We use `forge coverage` to measure coverage. It run the tests and returns 4 measures:
 
-- `% Lines`: the portion of line from the source file which have been seen by the tests, i.e. the number of lines seen in X.sol divided by total number of lines in X.sol * 100.
+- `% Lines`: the portion of line from the source file which have been seen by the tests, i.e. the number of lines seen in X.sol divided by total number of lines in X.sol \* 100.
 - `% Statements`: the portion of statements seen
 - `% Branches`: the portion of branches seen
 - `% Funcs`: the portion of function seen
@@ -350,9 +350,9 @@ To efficiently spot where the holes in our coverage are, we can use the [Coverag
 We use the branches coverage as a guiding tool, as it carries the most information possible. We want to hit 100% of branches coverage by the end of the development phase, taking into account 2 factors:
 
 - in rare cases, some branches are considered as unreachable
-- getting to 100% can be sometimes tedious or pointless. During active development, the main objective is therefore to aim for *meaningful* unit tests instead. Coverage might be, temporarily, non maximal, but both expected behaviour and edge cases are tested, allowing further iteration around the unit.
+- getting to 100% can be sometimes tedious or pointless. During active development, the main objective is therefore to aim for _meaningful_ unit tests instead. Coverage might be, temporarily, non maximal, but both expected behaviour and edge cases are tested, allowing further iteration around the unit.
 
-In Summary, we use coverage as a *discovery tool* instead of a *performance indicator*, a non-maximal coverage should always be investigated (while a 100% on all metric is not carrying much information).
+In Summary, we use coverage as a _discovery tool_ instead of a _performance indicator_, a non-maximal coverage should always be investigated (while a 100% on all metric is not carrying much information).
 
 ## Bulloak
 
@@ -439,19 +439,19 @@ Alternatively, running Bulloak without `-w` will output the scaffolded test in t
 
 ### TDD in a BTT-lead test suite
 
-The tree can be seen as a concise but exhaustive design document. It, therefore, makes sense to use it as such and adopt a TDD approach to the development and test.  The "3 Laws of TDD" ("You are not allowed to write any production code unless it is to make a failing unit test pass - You are not allowed to write any more of a unit test than is sufficient to fail, and compilation failures are failures - You are not allowed to write any more production code than is sufficient to pass the one failing unit test." - Clean Code, R. Martin) are the used, which leads to the following steps of short-lived repeated iterations:
+The tree can be seen as a concise but exhaustive design document. It, therefore, makes sense to use it as such and adopt a TDD approach to the development and test. The "3 Laws of TDD" ("You are not allowed to write any production code unless it is to make a failing unit test pass - You are not allowed to write any more of a unit test than is sufficient to fail, and compilation failures are failures - You are not allowed to write any more production code than is sufficient to pass the one failing unit test." - Clean Code, R. Martin) are the used, which leads to the following steps of short-lived repeated iterations:
 
 1. Start by writing the tree of the unit
 2. Pick one of the tree branches
-3. Write a single test that fails, based on that branch (compilation error counts as failing) 
-4. Write the code that makes that test pass, *and nothing more*
+3. Write a single test that fails, based on that branch (compilation error counts as failing)
+4. Write the code that makes that test pass, _and nothing more_
 5. If not covering every branch, go to 2.
 
 ### Internal functions
 
 Internal function testing might not be as straightforward as their external counterpart, as they're, well, internal to the contract. Even though internal and private functions are rather considered as implementation details in the software industry and not tested in isolation, we test them via a dedicated contract. This comes with an testing overhead when refactoring an unit, as there is a tighter coupling between the code and the test suite, which then needs refactoring too, but ease writing the initial unit tests.
 
-See the [Foundry's book related chapter](https://book.getfoundry.sh/tutorials/best-practices#internal-functions) for more tips and tricks.
+<!-- See the [Foundry's book related chapter](https://book.getfoundry.sh/tutorials/best-practices#internal-functions) for more tips and tricks. -->
 
 ### Fixtures
 
@@ -459,7 +459,7 @@ There is now [a foundry book part](https://book.getfoundry.sh/forge/fuzz-testing
 
 ## Integration tests
 
-While unit tests are studying the behaviour of an unit in *solitary* testing, unforeseen bugs might arise from interaction between multiple well-tested units. This is why we include integration tests in our development phase.
+While unit tests are studying the behaviour of an unit in _solitary_ testing, unforeseen bugs might arise from interaction between multiple well-tested units. This is why we include integration tests in our development phase.
 
 Integration tests are focused on studying how our units interact with each other or with external dependencies and protocols. They, therefore, don't focus on having every branches of every unit covered, because unit tests are already providing this information, and use another approach: happy and sad paths.
 
@@ -493,7 +493,7 @@ In this example, the happy path would be the sequence `baz()` `bar()` while a sa
 
 ## Fuzzed variables
 
-We use fuzzed variables in our tests, to cover a range of value corresponding *to a single branch or path* in an unit or integration tests.
+We use fuzzed variables in our tests, to cover a range of value corresponding _to a single branch or path_ in an unit or integration tests.
 
 What is fuzzing and how does it work? When adding a fuzzed variable to a test, there is no magic value used while writing it. Instead, forge will execute the same test an arbitrary number of times (256 by default) with a different value for this variable on each pass. One of these test iteration is called a "run". The underlying process is handled by a runner, which is outside the scope of this guide, see the amazing [Fuzzing Book](https://www.fuzzingbook.org/) for more general consideration on fuzzed tests.
 


### PR DESCRIPTION
Update/fix broken documentation links

ISSUE CHA-348 https://linear.app/defi-wonderland/issue/CHA-348/wonderland-handbook-invalid-links-broken-non-public-or-pointing-to

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Improved formatting, spacing, and stylistic consistency across multiple documentation pages, including normalization of list indentation and emphasis formatting.
  * Updated and corrected several reference links to point to current or official resources.
  * Clarified the design pattern reference for the Pricing Module's provider selection.
  * Added a note about the privacy status of Solidity security challenges with a call to follow for updates.
  * Revised contribution guidelines with improved formatting and updated the open roles URL.
  * Removed an outdated warning note regarding SSH key configuration for Windows (WSL) users.
  * Added clarifications on project tracking link privacy and improved readability in DeFi challenge documentation.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->