### PR TITLE
fix: searchbar overlapping wonderland logo

### DIFF
--- a/packages/common-config/static/common/styles/global.css
+++ b/packages/common-config/static/common/styles/global.css
@@ -473,6 +473,7 @@ nav.navbar.navbar--fixed-top + .main-wrapper {
     system-ui,
     -apple-system,
     sans-serif;
+  z-index: 1000;
 }
 
 .navbar__search-input::placeholder {


### PR DESCRIPTION
Demo:

https://github.com/user-attachments/assets/83f00b39-7c5b-4e6a-b85c-f1f7cc5e8a87



Issue https://linear.app/defi-wonderland/issue/CHA-358/navbar-logo-overlapping-searchbar

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Improved the visibility of the search input in the navbar by ensuring it appears above overlapping elements.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->