### PR TITLE
fix: broken link syntax for styled() refference

### DIFF
--- a/sites/wonderland/docs/development/frontend/best-practices.md
+++ b/sites/wonderland/docs/development/frontend/best-practices.md
@@ -164,7 +164,7 @@ const Button = () => {
 export default Button;
 ```
 
-Or using [\*\*``styled()](https://mui.com/system/styled/?srsltid=AfmBOoq0FmJ0KjHaNEZYbCgi1CbkOamY-AwtPiSm0tDtQ9Bdp7GIY3sd)``\*\* utility from MUI:
+Or using **[`styled()`](https://mui.com/system/styled/)** utility from MUI:
 
 ```jsx
 import { styled } from "@mui/material/styles";


### PR DESCRIPTION
Current behaviour:
<img width="674" height="132" alt="Screenshot 2025-08-05 at 5 09 50 PM" src="https://github.com/user-attachments/assets/e2605bec-055a-420b-accb-aa40d91e4bf8" />

New behaviour:
<img width="310" height="60" alt="Screenshot 2025-08-05 at 5 05 53 PM" src="https://github.com/user-attachments/assets/a298e2bd-6a70-49d1-836f-1094ffbd04fa" />


Closes https://linear.app/defi-wonderland/issue/CHA-380/wonderland-handbook-incorrect-link-format