### PR TITLE
fix: line spacing in home cards

### DIFF
--- a/packages/common-config/src/components/CategoryCards/styles.module.css
+++ b/packages/common-config/src/components/CategoryCards/styles.module.css
@@ -85,7 +85,7 @@
     sans-serif;
   font-weight: 500;
   font-size: 1rem;
-  line-height: 0.7;
+  line-height: 1.2;
   padding-top: 0.15em;
   color: var(--wonderland-gray-100);
   margin: 0;


### PR DESCRIPTION
Fixes the bug describe in https://github.com/defi-wonderland/handbook/pull/84#discussion_r2387502937
<img width="286" height="356" alt="Screenshot 2025-09-30 at 10 39 43 AM" src="https://github.com/user-attachments/assets/7436ff74-a45e-4298-ab43-6d34e166b504" />
